### PR TITLE
Added ctype.h header file

### DIFF
--- a/cwwav.c
+++ b/cwwav.c
@@ -35,6 +35,7 @@
 #include <locale.h>
 #include <wchar.h>
 #include <wctype.h>
+#include <ctype.h>
 
 #if 0
 #define dprintf(args...) fprintf(stderr, args)


### PR DESCRIPTION
Removes "implicit declaration of function ‘isspace’" error on compile