### PR TITLE
Program segfaults when it receives wide characters as input

### DIFF
--- a/cwwav.c
+++ b/cwwav.c
@@ -490,7 +490,7 @@ void text_to_morse(FILE *f) {
 			space++;
 			continue;
 		}
-		if (isspace(c)) {
+		if (iswspace(c)) {
 			space++;
 			continue;
 		}


### PR DESCRIPTION
Even though the program uses fgetwc(f) in line 485 to extract a wide character (wint_t c), the following isspace(c) function doesn't expect a wide character input. So my change uses iswspace(c) to fix the behavior of the program.